### PR TITLE
fix: Fix multibase [DEV-2307]

### DIFF
--- a/packages/credential-ld/src/suites/Ed25519Signature2020.ts
+++ b/packages/credential-ld/src/suites/Ed25519Signature2020.ts
@@ -48,7 +48,7 @@ export class VeramoEd25519Signature2020 extends VeramoLdSignature {
     const verificationKey = new Ed25519VerificationKey2020({
       id,
       controller,
-      publicKeyMultibase: this.preSigningKeyModification(u8a.fromString(key.publicKeyHex, 'hex')),
+      publicKeyMultibase: u8a.toString(u8a.fromString(key.publicKeyHex, 'hex'), 'base58btc'),
       // signer: () => signer,
       // type: this.getSupportedVerificationType(),
     })
@@ -71,10 +71,5 @@ export class VeramoEd25519Signature2020 extends VeramoLdSignature {
 
   preDidResolutionModification(didUrl: string, didDoc: DIDDocument): void {
     // nothing to do here
-  }
-
-  preSigningKeyModification(key: Uint8Array): string {
-    const modifiedKey = u8a.concat([this.MULTICODEC_PREFIX, key])
-    return `${this.MULTIBASE_BASE58BTC_PREFIX}${u8a.toString(modifiedKey, 'base58btc')}`
   }
 }

--- a/packages/credential-ld/src/suites/Ed25519Signature2020.ts
+++ b/packages/credential-ld/src/suites/Ed25519Signature2020.ts
@@ -48,7 +48,7 @@ export class VeramoEd25519Signature2020 extends VeramoLdSignature {
     const verificationKey = new Ed25519VerificationKey2020({
       id,
       controller,
-      publicKeyMultibase: u8a.toString(u8a.fromString(key.publicKeyHex, 'hex'), 'base58btc'),
+      publicKeyMultibase: this.preSigningKeyModification(u8a.fromString(key.publicKeyHex, 'hex')),
       // signer: () => signer,
       // type: this.getSupportedVerificationType(),
     })
@@ -71,5 +71,10 @@ export class VeramoEd25519Signature2020 extends VeramoLdSignature {
 
   preDidResolutionModification(didUrl: string, didDoc: DIDDocument): void {
     // nothing to do here
+  }
+
+  preSigningKeyModification(key: Uint8Array): string {
+    const modifiedKey = u8a.concat([this.MULTICODEC_PREFIX, key])
+    return `${this.MULTIBASE_BASE58BTC_PREFIX}${u8a.toString(modifiedKey, 'base58btc')}`
   }
 }

--- a/packages/utils/src/did-utils.ts
+++ b/packages/utils/src/did-utils.ts
@@ -138,7 +138,7 @@ function extractPublicKeyBytes(pk: VerificationMethod): Uint8Array {
   if (pk.publicKeyBase58) {
     return base58ToBytes(pk.publicKeyBase58)
   } else if (pk.publicKeyMultibase) {
-    return bases['base58btc'].decode(pk.publicKeyMultibase)
+    return bases['base58btc'].decode(pk.publicKeyMultibase).subarray(2)
   } else if ((<LegacyVerificationMethod>pk).publicKeyBase64) {
     return base64ToBytes((<LegacyVerificationMethod>pk).publicKeyBase64)
   } else if (pk.publicKeyHex) {
@@ -348,7 +348,7 @@ export function extractPublicKeyHex(pk: _ExtendedVerificationMethod, convert: bo
       ['Ed25519', 'Ed25519VerificationKey2018', 'Ed25519VerificationKey2020'].includes(pk.type) ||
       (pk.type === 'JsonWebKey2020' && pk.publicKeyJwk?.crv === 'Ed25519')
     ) {
-      keyBytes = extractPublicKeyX25519(keyBytes, pk.type)
+      keyBytes = convertPublicKeyToX25519(keyBytes)
     } else if (
       !['X25519', 'X25519KeyAgreementKey2019', 'X25519KeyAgreementKey2020'].includes(pk.type) &&
       !(pk.type === 'JsonWebKey2020' && pk.publicKeyJwk?.crv === 'X25519')
@@ -357,12 +357,4 @@ export function extractPublicKeyHex(pk: _ExtendedVerificationMethod, convert: bo
     }
   }
   return u8a.toString(keyBytes, 'base16')
-}
-
-function extractPublicKeyX25519(keyBytes: Uint8Array, type: string) {
-    if (keyBytes.length === 34 && type === 'Ed25519VerificationKey2020') {
-        keyBytes = keyBytes.slice(2)
-    }
-
-    return convertPublicKeyToX25519(keyBytes)
 }

--- a/packages/utils/src/did-utils.ts
+++ b/packages/utils/src/did-utils.ts
@@ -348,7 +348,7 @@ export function extractPublicKeyHex(pk: _ExtendedVerificationMethod, convert: bo
       ['Ed25519', 'Ed25519VerificationKey2018', 'Ed25519VerificationKey2020'].includes(pk.type) ||
       (pk.type === 'JsonWebKey2020' && pk.publicKeyJwk?.crv === 'Ed25519')
     ) {
-      keyBytes = convertPublicKeyToX25519(keyBytes)
+      keyBytes = extractPublicKeyX25519(keyBytes, pk.type)
     } else if (
       !['X25519', 'X25519KeyAgreementKey2019', 'X25519KeyAgreementKey2020'].includes(pk.type) &&
       !(pk.type === 'JsonWebKey2020' && pk.publicKeyJwk?.crv === 'X25519')
@@ -356,8 +356,13 @@ export function extractPublicKeyHex(pk: _ExtendedVerificationMethod, convert: bo
       return ''
     }
   }
-  if(pk.publicKeyMultibase) {
-    keyBytes = keyBytes.slice(2)
-  }
   return u8a.toString(keyBytes, 'base16')
+}
+
+function extractPublicKeyX25519(keyBytes: Uint8Array, type: string) {
+    if (keyBytes.length === 34 && type === 'Ed25519VerificationKey2020') {
+        keyBytes = keyBytes.slice(2)
+    }
+
+    return convertPublicKeyToX25519(keyBytes)
 }

--- a/packages/utils/src/did-utils.ts
+++ b/packages/utils/src/did-utils.ts
@@ -356,5 +356,8 @@ export function extractPublicKeyHex(pk: _ExtendedVerificationMethod, convert: bo
       return ''
     }
   }
+  if(pk.publicKeyMultibase) {
+    keyBytes = keyBytes.slice(2)
+  }
   return u8a.toString(keyBytes, 'base16')
 }

--- a/packages/utils/src/types/utility-types.ts
+++ b/packages/utils/src/types/utility-types.ts
@@ -28,7 +28,7 @@ export interface _ExtendedIKey extends IKey {
  */
 export type _NormalizedVerificationMethod = Omit<
   VerificationMethod,
-  'publicKeyBase58' | 'publicKeyBase64' | 'publicKeyJwk'
+  'publicKeyBase58' | 'publicKeyBase64' | 'publicKeyJwk' | 'publicKeyMultibase'
 >
 
 /**


### PR DESCRIPTION
## What issue is this PR fixing
fixes #1139 

## What is being changed
This PR slices the two-byte prefix 0xed01 in publicKeyMultibase according to the [spec](https://www.w3.org/community/reports/credentials/CG-FINAL-di-eddsa-2020-20220724/#ed25519verificationkey2020) in extractPublicKeyHex function

## Quality
Check all that apply:
* [X] I want these changes to be integrated
* [X] I successfully ran pnpm i, pnpm build, pnpm test, pnpm test:browser locally.
* [X] I allow my PR to be updated by the reviewers (to speed up the review process).

## Details
If applicable, add screen captures, error messages or stack traces to help explain your problem.
